### PR TITLE
feat: 모바일 사이즈에서 사이드바, 스크롤네비로 페이지 이동시 페이지 스크롤 대응

### DIFF
--- a/src/app/(recoil)/(wrap)/docs/layout.tsx
+++ b/src/app/(recoil)/(wrap)/docs/layout.tsx
@@ -9,13 +9,13 @@ export default function Layout({
   
   return (
     <div className="grid place-items-center">
+      <div className="z-[5] block w-full sticky top-[4rem] md:hidden">
+        <Sidebar />
+        <ScrollNav/>
+      </div>
       <div className="max-w-screen-xl display flex-row w-full md:flex">
         <div className="hidden md:block">
           <Sidebar />
-        </div>
-        <div className="block md:hidden">
-          <Sidebar />
-          <ScrollNav/>
         </div>
         <div className="flex flex-row w-full">
           <div className="w-full px-8 py-10 lg:px-12">

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -87,7 +87,7 @@ const Header: React.FC<{ sideMenuList:SideMenu[] }> = ({ sideMenuList }) => {
 
   return (
     <>
-      <div className="border-b border-zinc-200 grid place-items-center sticky top-0 z-10 backdrop-filter-blur-8 bg-white bg-opacity-85 dark:bg-opacity-85 dark:bg-backDarkColor dark:border-zinc-700">
+      <div className="z-10 border-b border-zinc-200 grid place-items-center sticky top-0 backdrop-filter-blur-8 bg-white bg-opacity-85 dark:bg-opacity-85 dark:bg-backDarkColor dark:border-zinc-700">
         <nav className="flex flex-row items-center max-w-screen-xl w-full h-16">
           <Link className="ml-6 mr-10 text-lg font-medium" href="/">
             <Image className="block dark:hidden" src="/images/logo.png" alt="로고" width="120" height="45"/>
@@ -114,7 +114,7 @@ const Header: React.FC<{ sideMenuList:SideMenu[] }> = ({ sideMenuList }) => {
         </nav>
       </div>
       {toggle &&
-        <div className="flex flex-col justify-between fixed top-16 px-4 pt-4 pb-20 bg-backColor border-t border-zinc-200 w-full h-full md:hidden dark:bg-backDarkColor dark:border-zinc-700">
+        <div className="z-10 flex flex-col justify-between fixed top-16 px-4 pt-4 pb-20 bg-backColor border-t border-zinc-200 w-full h-full md:hidden dark:bg-backDarkColor dark:border-zinc-700">
           <div>
             <Link className="text-sm pl-2 h-9 my-1 flex items-center rounded text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-neutral-800" href="/docs/string" onClick={() => mobileMovePage("/docs/string")}>문서</Link>
             <Link className="text-sm pl-2 h-9 my-1 flex items-center rounded text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-neutral-800" href="/notice" onClick={() => mobileMovePage("/notice")}>공지사항</Link>

--- a/src/components/scrollNav/favoritesAccordion/index.tsx
+++ b/src/components/scrollNav/favoritesAccordion/index.tsx
@@ -11,6 +11,7 @@ import { sideMenuData } from '@/recoil/sideMenuAtom';
 import { usePathname } from "next/navigation";
 import StarRateIcon from '@mui/icons-material/StarRate';
 import Image from "next/image";
+import { updateHash } from "@/utils/navigationUtils";
 
 const FavoritesAccordion: React.FC = () => {
   const [user, setUser] = useRecoilState<User>(userData);
@@ -18,7 +19,24 @@ const FavoritesAccordion: React.FC = () => {
   const [sideMenu, setSideMenu] = useRecoilState<SideMenu[]>(sideMenuData);
   const [faoritesIDList, setFaoritesIDList] = useRecoilState(favoritesIDData);
   const [favoritesDocsList, setFavoritesDocsList] = useRecoilState(favoritesDocsData);
+  const [isMobile, setIsMobile] = useState(false);
   const pathName = usePathname();
+
+  useEffect(() => {
+    const handleResize = () => {
+      const isMobileState = window.innerWidth < 768;
+      setIsMobile(isMobileState);
+    };
+
+    handleResize();
+
+    // 화면 리사이즈 감지
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
 
   useEffect(() => {
     if(user && user.user_id){
@@ -29,7 +47,7 @@ const FavoritesAccordion: React.FC = () => {
 
   useEffect(() => {
     setLoadState(false);
-  },[favoritesDocsList])
+  },[favoritesDocsList]);
 
   const getFavoritesList = async () => {
     const resp = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/favorites?user_id=${user.user_id}`, { cache: 'no-store' });
@@ -58,19 +76,34 @@ const FavoritesAccordion: React.FC = () => {
             : (favoritesDocsList && favoritesDocsList.length > 0)
               ? favoritesDocsList.map((docs) => (
                   <div className="pb-3" key={`favories_${docs.id}`}>
-                    {pathName === docs.link
-                    ?<a
-                      href={`#docs${docs.id}`}
-                      className={"block text-xs font-semibold cursor-pointer hover:text-blue-500 dark:hover:text-blue-500"}
-                    >
-                      {docs.favorites_title ? docs.favorites_title : docs.title}
-                    </a>
-                    :<Link
-                      href={`${docs.link}#docs${docs.id}` ?? ''}
-                      className={"block text-xs font-semibold cursor-pointer hover:text-blue-500 dark:hover:text-blue-500"}
-                    >
-                      {docs.favorites_title ? docs.favorites_title : docs.title}
-                    </Link>}
+                    {isMobile
+                    ?pathName === docs.link
+                      ?<div
+                        onClick={() => updateHash(`#docs${docs.id}`)}
+                        className={"block text-xs font-semibold cursor-pointer hover:text-blue-500 dark:hover:text-blue-500"}
+                      >
+                        {docs.favorites_title ? docs.favorites_title : docs.title}
+                      </div>
+                      :<Link
+                        href={`${docs.link}`}
+                        onClick={() => updateHash(`#docs${docs.id}`)}
+                        className={"block text-xs font-semibold cursor-pointer hover:text-blue-500 dark:hover:text-blue-500"}
+                      >
+                        {docs.favorites_title ? docs.favorites_title : docs.title}
+                      </Link>
+                    :pathName === docs.link
+                      ?<a
+                        href={`#docs${docs.id}`}
+                        className={"block text-xs font-semibold cursor-pointer hover:text-blue-500 dark:hover:text-blue-500"}
+                      >
+                        {docs.favorites_title ? docs.favorites_title : docs.title}
+                      </a>
+                      :<Link
+                        href={`${docs.link}#docs${docs.id}`}
+                        className={"block text-xs font-semibold cursor-pointer hover:text-blue-500 dark:hover:text-blue-500"}
+                      >
+                        {docs.favorites_title ? docs.favorites_title : docs.title}
+                      </Link>}
                   </div>))
               : <div className={"text-xs font-semibold text-gray-500 dark:text-gray-400"}>즐겨찾기하는 문서가 없습니다</div>
           : <div className={"text-xs font-semibold text-gray-500 dark:text-gray-400"}>로그인 후 즐겨찾기 하세요!</div>

--- a/src/components/scrollNav/favoritesAccordion/index.tsx
+++ b/src/components/scrollNav/favoritesAccordion/index.tsx
@@ -67,7 +67,7 @@ const FavoritesAccordion: React.FC = () => {
         즐겨찾기
         <StarRateIcon className="text-base ml-2 text-yellow-400"/>
       </div>
-      <div>
+      <div className="max-h-32 md:max-h-none overflow-auto">
         {(user && user.user_id)
           ? loadState
             ? <div className="flex justify-center">

--- a/src/components/scrollNav/index.tsx
+++ b/src/components/scrollNav/index.tsx
@@ -11,11 +11,14 @@ import { sideMenuData } from "@/recoil/sideMenuAtom";
 import { extractDocsData } from "@/utils/sideMenuData";
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import { updateHash } from "@/utils/navigationUtils";
 
 const ScrollNav: React.FC = () => {
   const [sideToDocs, setSideToDocs] = useRecoilState<SideMenu[]>(sideMenuData);
   const [scrollList, setScrollList] = useState<Docs[]|[]>([]);
   const [toggle, setToggle] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
+  const [hash, setHash] = useState('');
   const pathName = usePathname();
 
   useEffect(()=>{
@@ -24,38 +27,94 @@ const ScrollNav: React.FC = () => {
       const { data: docsData } = extractDocsData(sideToDocs, pathSplit[2], pathSplit[3]);
       setScrollList(docsData);
     }
+    setToggle(false);
   },[sideToDocs, pathName]);
 
-  useEffect(()=>{
-    setToggle(false);
-  },[pathName]);
+  useEffect(() => {
+    const handleResize = () => {
+      const isMobileState = window.innerWidth < 768;
+      setIsMobile(isMobileState);
+      return isMobileState;
+    };
+
+    if(handleResize()) {
+      hashScrollController();
+    }
+
+    // 화면 리사이즈 감지
+    window.addEventListener('resize', handleResize);
+    // 해시 변경 이벤트 감지
+    window.addEventListener('hashchange', hashScrollController);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      window.removeEventListener('hashchange', hashScrollController);
+    };
+  }, []);
 
   const toggleMenu = () => {
     setToggle(!toggle);
   };
 
+  const hashScrollController = () => {
+    setToggle(false);
+
+    const hash = window.location.hash;
+    if(hash) {
+      // 대상 요소 가져오기
+      const targetElement = document.querySelector(hash);
+
+      // 요소가 존재하지 않으면
+      if (!targetElement) {
+        setTimeout(() => {
+          const retryElement = document.querySelector(hash);
+          if (retryElement) {
+            scrollToElement(retryElement);
+          }
+        }, 100); // 100ms 후에 다시 시도
+      } else {
+        scrollToElement(targetElement);
+      }
+    }
+  }
+
+  const scrollToElement = (element: Element) => {
+    const yOffset = -100; // 스크롤 오프셋 값 (100px 위로)
+    const y = element.getBoundingClientRect().top + window.pageYOffset + yOffset;
+    // 스크롤 위치 조정
+    window.scrollTo({
+      top: y,
+    });
+  };
+
   return (
     <div className="h-full">
-      <div className="text-sm border-solid border-b border-zinc-200 dark:border-zinc-700 cursor-pointer flex justify-between items-center px-4 py-3 md:hidden" onClick={toggleMenu}>
+      <div className="text-sm border-solid border-b border-zinc-200 dark:border-zinc-700 bg-white dark:bg-backDarkColor cursor-pointer flex justify-between items-center px-4 py-3 md:hidden" onClick={toggleMenu}>
         <p className="text-gray-600 dark:text-gray-300">빠른 이동</p>
         {toggle ? <KeyboardArrowUpIcon/> : <KeyboardArrowDownIcon/>}
       </div>
-      <div className={["border-solid border-zinc-200 dark:border-zinc-700 overflow-auto transition-max-height duration-500", toggle ? 'max-h-screen border-b md:border-hidden' : 'max-h-0 md:max-h-screen',"min-w-56 sticky top-16"].join(' ')}>
-        <div className="min-w-56 px-4 py-6">
+      <div className={["border-solid border-zinc-200 dark:border-zinc-700 overflow-auto transition-max-height duration-500", toggle ? 'max-h-screen border-b md:border-hidden' : 'max-h-0 md:max-h-remaining',"min-w-56 sticky top-16"].join(' ')}>
+        <div className="min-w-56 px-4 py-6 bg-white dark:bg-backDarkColor">
           <FavoritesAccordion/>
           <div className="w-full h-px bg-zinc-200 my-4 dark:bg-zinc-700"></div>
           {scrollList.length > 0 &&
             <>
               <div className="text-sm font-semibold mb-5">현재 페이지</div>
               {scrollList.map((scrollInfo) => (
-                <div className="pb-3" key={`scrollTitle_${scrollInfo.id}`}>
+                isMobile
+                ?<div className="pb-3" key={`scrollTitle_${scrollInfo.id}`}>
+                  <div className="block text-xs font-semibold cursor-pointer hover:text-blue-500 dark:hover:text-blue-500" onClick={() => updateHash(`#docs${scrollInfo.id}`)}>{scrollInfo.favorites_title ? scrollInfo.favorites_title : scrollInfo.title}</div>
+                </div>
+                :<div className="pb-3" key={`scrollTitle_${scrollInfo.id}`}>
                   <a className="block text-xs font-semibold cursor-pointer hover:text-blue-500 dark:hover:text-blue-500" href={`#docs${scrollInfo.id}`}>{scrollInfo.favorites_title ? scrollInfo.favorites_title : scrollInfo.title}</a>
                 </div>
               ))}
               <div className="w-full h-px bg-zinc-200 my-4 dark:bg-zinc-700"></div>
             </>
           }
-          <Link className="text-sm flex items-center text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100" target="_blank" href="https://github.com/fjdkslvn/quick-js/issues/new">
+          <Link
+            className="text-sm flex items-center text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100" target="_blank" href="https://github.com/fjdkslvn/quick-js/issues/new"
+          >
             질문 및 피드백 제안 <QuestionAnswerIcon className="text-sm ml-2"/>
           </Link>
         </div>

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -21,13 +21,31 @@ const Sidebar: React.FC = () => {
     setPathNameList(pathName.split('/'));
   },[pathName]);
 
+  useEffect(() => {
+    const handleHashLisner = () => {
+      setToggle(false);
+    }
+
+    // 해시 변경 이벤트 감지
+    window.addEventListener('hashchange', handleHashLisner);
+
+    return () => {
+      window.removeEventListener('hashchange', handleHashLisner);
+    };
+  }, []);
+
   const toggleMenu = () => {
     setToggle(!toggle);
   };
 
+  const handleLinkClick = () => {
+    window.scrollTo(0, 0);
+  };
+
   return (
     <div className="h-full">
-      <div className="border-solid border-b border-zinc-200 dark:border-zinc-700 cursor-pointer flex justify-between items-center px-4 py-3 md:hidden" onClick={toggleMenu}>
+      {/* 모바일 화면 토글 */}
+      <div className="border-solid border-b border-zinc-200 dark:border-zinc-700 bg-white dark:bg-backDarkColor cursor-pointer flex justify-between items-center px-4 py-3 md:hidden" onClick={toggleMenu}>
         {pathNameList.length > 3
         ? <div className="flex text-sm w-full items-end text-gray-600 dark:text-gray-300">
             <p>{pathNameList[2]}</p>
@@ -39,12 +57,13 @@ const Sidebar: React.FC = () => {
           </div>}
         {toggle ? <KeyboardArrowUpIcon/> : <KeyboardArrowDownIcon/>}
       </div>
-      <nav className={["border-solid border-zinc-200 dark:border-zinc-700 overflow-auto transition-max-height duration-500", toggle ? 'max-h-screen border-b md:border-hidden' : 'max-h-0 md:max-h-screen',"min-w-56 sticky top-16"].join(' ')}>
-        <div className="px-6 py-4">
+      <nav className={["border-solid border-zinc-200 dark:border-zinc-700 bg-white dark:bg-backDarkColor overflow-auto transition-max-height duration-500", toggle ? 'max-h-screen border-b md:border-hidden' : 'max-h-0 md:max-h-remaining',"min-w-56 sticky top-16"].join(' ')}>
+        <div className="px-6 py-4 max-h-[20rem] overflow-auto md:max-h-none md:overflow-hidden">
           {sideMenu?.map((menu) => (
             <div className="text-sm" key={`menu_${menu.id}`}>
               <Link
                 href={menu.link}
+                onClick={handleLinkClick}
                 className={pathName === menu.link
                             ? "text-blue-500 font-bold px-2 h-9 my-1 flex items-center rounded hover:bg-gray-100 dark:hover:bg-neutral-800"
                             : "text-gray-600 px-2 h-9 my-1 flex items-center rounded hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100 dark:hover:bg-neutral-800"}
@@ -57,6 +76,7 @@ const Sidebar: React.FC = () => {
                       <div className="w-px h-10 mx-3 bg-gray-300 dark:bg-gray-600"></div>
                       <Link
                         href={sub_menu.link}
+                        onClick={handleLinkClick}
                         className={pathName === sub_menu.link
                                     ? "w-full text-blue-500 font-bold px-2 h-9 flex items-center rounded my-0.5"
                                     : "w-full text-gray-600 px-2 h-9 flex items-center rounded my-0.5 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100 dark:hover:bg-neutral-800"}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -37,7 +37,7 @@ textarea{
 .visible-mobile{
   display: none;
 }
-@media (max-width: 767px) {
+@media (max-width: 48rem) {
 .visible-mobile{
     display: block;
   }
@@ -45,13 +45,12 @@ textarea{
 .invisible-mobile{
   display: block;
 }
-@media (max-width: 767px) {
+@media (max-width: 48rem) {
 .invisible-mobile{
     display: none;
   }
 }
 
-
 .backdrop-filter-blur-8 {
-  backdrop-filter: blur(8px);
+  backdrop-filter: blur(0.5rem);
 }

--- a/src/utils/navigationUtils.ts
+++ b/src/utils/navigationUtils.ts
@@ -1,0 +1,6 @@
+// 해시 업데이트
+export const updateHash = (hash: string) => {
+  history.pushState(null, "", hash);
+  const hashChangeEvent = new Event("hashchange");
+  window.dispatchEvent(hashChangeEvent);
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,12 +14,15 @@ const config: Config = {
           "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
       },
       colors: {
-        backColor : '#ffffff',
-        backDarkColor : 'rgb(17, 17, 17)',
+        backColor: "#ffffff",
+        backDarkColor: "rgb(17, 17, 17)",
+      },
+      maxHeight: {
+        remaining: "calc(100vh - 8rem)",
       },
     },
   },
-  darkMode: 'class', // 다크 모드를 클래스 기반으로 설정
+  darkMode: "class", // 다크 모드를 클래스 기반으로 설정
   plugins: [],
 };
 export default config;


### PR DESCRIPTION
### 요구 사항
- 모바일 사이즈에서 메뉴들이 상단에 고정되어야 합니다.

### 작업 내용
- 모바일 사이즈에서 `sideBar`, `scrollNav`가 `position: sticky;`로 동작하도록 수정하였습니다.
- 모바일 사이즈에서 `sideBar`, `scrollNav`로 페이지 이동시 스크롤 위치가 조정됩니다.

### 예상 동작
해시가 변경되는것을 감지하여, 해시 요소 위치로 이동시 `sideBar`, `scrollNav`가 차지하는 높이만큼 스크롤을 조정합니다.
``` ts
// 해시 변경 이벤트 감지
window.addEventListener('hashchange', hashScrollController);

return () => {
  window.removeEventListener('hashchange', hashScrollController);
```

### 스크린샷
<img width="507" alt="스크린샷 2025-01-16 오후 5 13 00" src="https://github.com/user-attachments/assets/67020589-c884-41f9-b2a3-89c0c47fc44f" />
